### PR TITLE
更新清华大学 thuthesis 的示例

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
 gbT7714-2015.dvi
+
+egthesis/*.aux
+egthesis/*.bbl
+egthesis/*.bcf
+egthesis/*.bib
+egthesis/*.blg
+egthesis/*.fdb_latexmk
+egthesis/*.fls
+egthesis/*.log
+egthesis/*.out
+egthesis/*.pdf
+egthesis/*.synctex.gz
+egthesis/*.synctex.gz(busy)
+egthesis/*.run.xml
+egthesis/*.pdf
+egthesis/*.xdv

--- a/egthesis/thesis-thu-author-year.tex
+++ b/egthesis/thesis-thu-author-year.tex
@@ -27,8 +27,8 @@
 
 \usepackage[
   backend   = biber,
-  % style     = numeric,
-  style     = gb7714-2015,
+  % style     = authoryear,
+  style     = gb7714-2015ay,
   gbnamefmt = lowercase,
   gbalign   = left,
   gbstrict  = true
@@ -36,9 +36,8 @@
 
 \renewcommand\bibfont{\fontsize{10.5bp}{16bp}\selectfont}
 \setlength{\bibitemsep}{3bp}
-\setlength{\labelnumberwidth}{0.8cm}
-\setlength{\biblabelsep}{0.2cm}
-\setlength{\bibhang}{0cm}
+\setlength{\bibhang}{21bp}
+\setlength{\bibitemindent}{-21bp}
 
 \usepackage{filecontents}
 \begin{filecontents}{\jobname.bib}
@@ -367,40 +366,40 @@
 
 \section*{THU}
 
-\cite{zhangkun1994}
-\cite{zhukezhen1973}
-\cite{dupont1974bone}
-\cite{zhengkaiqing1987}
-\cite{jiangxizhou1980}
-\cite{jianduju1994}
-\cite{merkt1995rotational}
-\cite{mellinger1996laser}
-\cite{bixon1996dynamics}
-\cite{mahui1995}
-\cite{carlson1981two}
-\cite{taylor1983scanning}
-\cite{taylor1981study}
-\cite{shimizu1983laser}
-\cite{atkinson1982experimental}
-\cite{kusch1975perturbations}
+\cite{zhangkun1994} \\
+\cite{zhukezhen1973} \\
+\cite{dupont1974bone} \\
+\cite{zhengkaiqing1987} \\
+\cite{jiangxizhou1980} \\
+\cite{jianduju1994} \\
+\cite{merkt1995rotational} \\
+\cite{mellinger1996laser} \\
+\cite{bixon1996dynamics} \\
+\cite{mahui1995} \\
+\cite{carlson1981two} \\
+\cite{taylor1983scanning} \\
+\cite{taylor1981study} \\
+\cite{shimizu1983laser} \\
+\cite{atkinson1982experimental} \\
+\cite{kusch1975perturbations} \\
 \cite{guangxi1993} \\
-\cite{huosini1989guwu}
-\cite{wangfuzhi1865songlun}
-\cite{zhaoyaodong1998xinshidai}
-\cite{biaozhunhua2002tushu}
-\cite{chubanzhuanye2004}
-\cite{who1970factors}
-\cite{peebles2001probability}
-\cite{baishunong1998zhiwu}
-\cite{weinstein1974pathogenic}
-\cite{hanjiren1985lun}
-\cite{dizhi1936dizhi}
-\cite{tushuguan1957tushuguanxue}
-\cite{aaas1883science}
-\cite{fugang2000fengsha}
-\cite{xiaoyu2001chubanye}
-\cite{oclc2000about}
-\cite{scitor2000project}
+\cite{huosini1989guwu} \\
+\cite{wangfuzhi1865songlun} \\
+\cite{zhaoyaodong1998xinshidai} \\
+\cite{biaozhunhua2002tushu} \\
+\cite{chubanzhuanye2004} \\
+\cite{who1970factors} \\
+\cite{peebles2001probability} \\
+\cite{baishunong1998zhiwu} \\
+\cite{weinstein1974pathogenic} \\
+\cite{hanjiren1985lun} \\
+\cite{dizhi1936dizhi} \\
+\cite{tushuguan1957tushuguanxue} \\
+\cite{aaas1883science} \\
+\cite{fugang2000fengsha} \\
+\cite{xiaoyu2001chubanye} \\
+\cite{oclc2000about} \\
+\cite{scitor2000project} \\
 
 \printbibliography
 


### PR DESCRIPTION
清华大学刚刚更新了研究生的学位论文写作指南（https://github.com/tuna/thuthesis/issues/564 ），其中的参考文献格式更新为 GB/T 7714-2015 版。 我在实现新版本的同时也打算加入 biblatex 的支持，顺便也更新一下这边的示例。