### PR TITLE
docs(readme): add \leavevmode in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ gbyntd 以语言、年份、作者、标题、降序排列
 \addvspace{\bibitemsep}%恢复\bibitemsep的作用
 %\parshape 2 0em \textwidth \lengthid \lengthlw
 \hangindent\lengthid
-\mkgbnumlabel{\printfield{labelnumber}}%
+\leavevmode\mkgbnumlabel{\printfield{labelnumber}}%
 \hspace{\biblabelsep}}
 ```
 


### PR DESCRIPTION
The old example won't compile anymore.

Add `\leavevmode` according to details in `\itemcmd` to fix this issue.