### PR TITLE
Update OL settings

### DIFF
--- a/gb7714-2015.bbx
+++ b/gb7714-2015.bbx
@@ -2355,7 +2355,7 @@ test {\iftoggle{iftlseven}}%biblatex<=3.7
 \DeclareFieldFormat{gbtypeflag}{%
 \iftoggle{bbx:gbmedium}%
 {\iftoggle{bbx:url}%
-    {\ifboolexpr{ test {\iffieldundef{url}} and test {\iffieldundef{doi}} and test {\iffieldundef{eprint}} }%\iffieldundef{url}%当存在url时，增加一个OL标识符->改为当存在doi或eprint时增加OL标识符
+    {\ifboolexpr{ test {\iffieldundef{url}} and test {\iffieldundef{doi}} and test {\iffieldundef{eprint}} }%\iffieldundef{url}%当存在url时，增加一个OL标识符->改为当存在doi或eprint或url时增加OL标识符
         {\printdelim{titletypedelim}\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{\iffieldundef{medium}{}{{\SlashFont/}\thefield{medium}}\gbrightbracket}}%
         {\printdelim{titletypedelim}\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{{\SlashFont/}OL\gbrightbracket}}%
     }%

--- a/gb7714-2015.bbx
+++ b/gb7714-2015.bbx
@@ -2355,7 +2355,7 @@ test {\iftoggle{iftlseven}}%biblatex<=3.7
 \DeclareFieldFormat{gbtypeflag}{%
 \iftoggle{bbx:gbmedium}%
 {\iftoggle{bbx:url}%
-    {\iffieldundef{url}%当存在url时，增加一个OL标识符
+    {\ifboolexpr{ test {\iffieldundef{url}} and test {\iffieldundef{doi}} and test {\iffieldundef{eprint}} }%\iffieldundef{url}%当存在url时，增加一个OL标识符->改为当存在doi或eprint时增加OL标识符
         {\printdelim{titletypedelim}\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{\iffieldundef{medium}{}{{\SlashFont/}\thefield{medium}}\gbrightbracket}}%
         {\printdelim{titletypedelim}\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{{\SlashFont/}OL\gbrightbracket}}%
     }%

--- a/gb7714-2015ay.bbx
+++ b/gb7714-2015ay.bbx
@@ -2213,7 +2213,7 @@ test {\iftoggle{iftlseven}}%biblatex<=3.7
 \DeclareFieldFormat{gbtypeflag}{%
 \iftoggle{bbx:gbmedium}%
 {\iftoggle{bbx:url}%
-    {\iffieldundef{url}%当存在url时，增加一个OL标识符
+    {\ifboolexpr{ test {\iffieldundef{url}} and test {\iffieldundef{doi}} and test {\iffieldundef{eprint}} }%\iffieldundef{url}%当存在url时，增加一个OL标识符->改为当存在doi或eprint或url时增加OL标识符
         {\printdelim{titletypedelim}\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{\iffieldundef{medium}{}{{\SlashFont/}\thefield{medium}}\gbrightbracket}}%
         {\printdelim{titletypedelim}\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{{\SlashFont/}OL\gbrightbracket}}%
     }%

--- a/gb7714-2015ms.bbx
+++ b/gb7714-2015ms.bbx
@@ -1445,7 +1445,7 @@
 \DeclareFieldFormat{gbtypeflag}{%
 \iftoggle{bbx:gbmedium}%
 {\iftoggle{bbx:url}%
-    {\iffieldundef{url}%当存在url时，增加一个OL标识符
+    {\ifboolexpr{ test {\iffieldundef{url}} and test {\iffieldundef{doi}} and test {\iffieldundef{eprint}} }%\iffieldundef{url}%当存在url时，增加一个OL标识符->改为当存在doi或eprint或url时增加OL标识符
         {\allowbreak\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{\iffieldundef{medium}{}{{\SlashFont/}\thefield{medium}}\gbrightbracket}}%
         {\allowbreak\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{{\SlashFont/}OL\gbrightbracket}}%
     }%

--- a/gb7714-2015mx.bbx
+++ b/gb7714-2015mx.bbx
@@ -1751,7 +1751,7 @@
 \DeclareFieldFormat{gbtypeflag}{%
 \iftoggle{bbx:gbmedium}%
 {\iftoggle{bbx:url}%
-    {\iffieldundef{url}%当存在url时，增加一个OL标识符
+    {\ifboolexpr{ test {\iffieldundef{url}} and test {\iffieldundef{doi}} and test {\iffieldundef{eprint}} }%\iffieldundef{url}%当存在url时，增加一个OL标识符->改为当存在doi或eprint或url时增加OL标识符
         {\allowbreak\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{\iffieldundef{medium}{}{{\SlashFont/}\thefield{medium}}\gbrightbracket}}%
         {\allowbreak\printtext{\gbleftbracket}\nobreak#1\nobreak\printtext{{\SlashFont/}OL\gbrightbracket}}%
     }%


### PR DESCRIPTION
目前的设置是仅在存在url时才会添加OL标识符。虽然根据gb7714-2015中4.4.1，url和doi应该同时具备，但通常从数据库进行文献导出时（如inspirehep）经常出现只有doi或者arxiv的eprint号而没有url的情况，此时导出的文献列表中虽然doi或arxiv eprint的电子链接，但却没有OL标识符。这里将添加OL标识符的条件修改为具有url，doi和eprint任意一个即可。