### PR TITLE
docs: 更正 gbT7714-2025.pdf 的 URL

### DIFF
--- a/biblatex-gb7714-2015.tex
+++ b/biblatex-gb7714-2015.tex
@@ -3826,7 +3826,7 @@ gb7714-2015实现了 GB/T 7714-2015 第 8.8 节要求的析出文献相关格式
 \section{GB/T 7714-2025 标准说明与实现}\label{sec:gbt25:std}
 
 GB/T 7714-2025 标准不再进行二次解读，而是直接复现标准的文件。标准的内容详见文件：
-\href{https://github.com/hushidong/biblatex-gb7714-2015/gbT7714-2025.pdf}{gbT7714-2025.pdf}。
+\href{https://github.com/hushidong/biblatex-gb7714-2025/blob/main/gbT7714-2025.pdf}{gbT7714-2025.pdf}。
 
 
 \section{总结与致谢}


### PR DESCRIPTION
这个 PDF 的链接缺少`/blob/main/`，而且文件挪到 2025 那个仓库了。
